### PR TITLE
add pattern search for inputfields

### DIFF
--- a/pi1/class.tx_staddressmap_pi1.php
+++ b/pi1/class.tx_staddressmap_pi1.php
@@ -292,8 +292,17 @@ class tx_staddressmap_pi1 extends tslib_pibase {
 			}
 		} else {
 			if ($this->isValidDatabaseColumn($what)) {
-				if ($this->conf['searchPlaceholderBefore'] && $this->conf['searchPlaceholderBefore'] == 1) {$placeholderBefore = '%';}
-				if ($this->conf['searchPlaceholderAfter'] && $this->conf['searchPlaceholderAfter'] == 1) {$placeholderAfter = '%';}
+				var_dump($this->conf);
+				if ($this->conf['searchPlaceholderBefore.'][$what]) {
+					if($this->conf['searchPlaceholderBefore.'][$what] == 1) {$placeholderBefore = '%';}
+				} else {
+					if ($this->conf['searchPlaceholderBefore'] && $this->conf['searchPlaceholderBefore'] == 1) {$placeholderBefore = '%';}
+				}
+				if ($this->conf['searchPlaceholderAfter.'][$what]) {
+					if($this->conf['searchPlaceholderAfter.'][$what] == 1) {$placeholderAfter = '%';}
+				} else {
+					if ($this->conf['searchPlaceholderAfter'] && $this->conf['searchPlaceholderAfter'] == 1) {$placeholderAfter = '%';}
+				}
 				$res = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
 					'uid, ' . (!empty($validDatabaseFields) ? implode(', ', $validDatabaseFields) . ', ' : '') . 'tx_staddressmap_lat, tx_staddressmap_lng',
 					'tt_address',

--- a/pi1/class.tx_staddressmap_pi1.php
+++ b/pi1/class.tx_staddressmap_pi1.php
@@ -292,7 +292,6 @@ class tx_staddressmap_pi1 extends tslib_pibase {
 			}
 		} else {
 			if ($this->isValidDatabaseColumn($what)) {
-				var_dump($this->conf);
 				if ($this->conf['searchPlaceholderBefore.'][$what]) {
 					if($this->conf['searchPlaceholderBefore.'][$what] == 1) {$placeholderBefore = '%';}
 				} else {

--- a/pi1/class.tx_staddressmap_pi1.php
+++ b/pi1/class.tx_staddressmap_pi1.php
@@ -72,7 +72,7 @@ class tx_staddressmap_pi1 extends tslib_pibase {
 		$templatefile = ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_staddressmap_pi1.']['templateFile']) ? ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_staddressmap_pi1.']['templateFile']) : ('EXT:st_address_map/static/template.html');
 		$this->templateHtml = $this->cObj->fileResource($templatefile);
 		$subpart = $this->cObj->getSubpart($this->templateHtml, '###TEMPLATE###');
-		
+
 		// errorhandling
 		$mapsettings = $this->cObj->data['pi_flexform']['data']['sDEF']['lDEF'];
 		if (is_array($mapsettings)) {
@@ -292,10 +292,12 @@ class tx_staddressmap_pi1 extends tslib_pibase {
 			}
 		} else {
 			if ($this->isValidDatabaseColumn($what)) {
+				if ($this->conf['searchPlaceholderBefore'] && $this->conf['searchPlaceholderBefore'] == 1) {$placeholderBefore = '%';}
+				if ($this->conf['searchPlaceholderAfter'] && $this->conf['searchPlaceholderAfter'] == 1) {$placeholderAfter = '%';}
 				$res = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
 					'uid, ' . (!empty($validDatabaseFields) ? implode(', ', $validDatabaseFields) . ', ' : '') . 'tx_staddressmap_lat, tx_staddressmap_lng',
 					'tt_address',
-					'(hidden=0 and deleted=0) and (pid = ' . $addresslist . ') and ' . $what . ' like "' . $GLOBALS['TYPO3_DB']->escapeStrForLike($var, 'tt_address') . '"'
+					'(hidden=0 and deleted=0) and (pid = ' . $addresslist . ') and ' . $what . ' like "' . $placeholderBefore . $GLOBALS['TYPO3_DB']->escapeStrForLike($var, 'tt_address') . $placeholderAfter . '"'
 				);
 			}
 		}

--- a/static/st_address_map/constants.txt
+++ b/static/st_address_map/constants.txt
@@ -59,6 +59,10 @@ plugin.tx_staddressmap_pi1 {
 	dropdownfields = city, region
 	# cat=Addressmap - Settings//0050; type=string; label= inputfields
 	inputfields = zip
+	# cat=Addressmap - Settings//0055; type=boolean; label= Put Placeholder before Search-String for inputfield
+	searchPlaceholderBefore = 0
+	# cat=Addressmap - Settings//0056; type=string; label= Put Placeholder after Search-String for inputfields
+	searchPlaceholderAfter = 0
 	# cat=Addressmap - Settings//0060; type=string; label= radiusfields: The field in which you want to search for.
 	radiusfields = zip
 	# cat=Addressmap - Settings//0070; type=int+; label= searchradius: Distance in kilometers

--- a/static/st_address_map/setup.txt
+++ b/static/st_address_map/setup.txt
@@ -66,6 +66,8 @@ plugin.tx_staddressmap_pi1 {
 	bubblefields =  {$plugin.tx_staddressmap_pi1.bubblefields}
 	dropdownfields = {$plugin.tx_staddressmap_pi1.dropdownfields}
 	inputfields = {$plugin.tx_staddressmap_pi1.inputfields}
+	searchPlaceholderBefore = {$plugin.tx_staddressmap_pi1.searchPlaceholderBefore}
+	searchPlaceholderAfter = {$plugin.tx_staddressmap_pi1.searchPlaceholderAfter}
 	radiusfields = {$plugin.tx_staddressmap_pi1.radiusfields}
 	searchradius = {$plugin.tx_staddressmap_pi1.searchradius}
 	radiuscountry = {$plugin.tx_staddressmap_pi1.radiuscountry}


### PR DESCRIPTION
Hi, 

I recently implemented st_address_map in a project where the client wanted to be able to search for the first two or three digits of a zip code and get all address-items that begin with the search query. So I added two TS options that allow the TYPO3-Webmaster to control if a searchfield should 
- be eqal searchquery (default, searchPlaceholderBefore = 0, searchPlaceholderAfter = 0)
- begin with searchquery (searchPlaceholderBefore = 0, searchPlaceholderAfter = 1)
- end with searchquery (searchPlaceholderBefore = 1, searchPlaceholderAfter = 0)
- contain searchquery (searchPlaceholderBefore = 1, searchPlaceholderAfter = 1)

The wording is a little bumpy but the additional options are useful in my opinion. Please consider allowing the changes into the main repository. 

Greetings
Daniel
